### PR TITLE
fix: drop correct event type

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -21,7 +21,7 @@
       const args = [].slice.call(arguments, 0);
       try {
         const parsed = JSON.parse(args[0] || '{}');
-        if (parsed.type === 'typing') {
+        if (parsed.type === 'user_typing') {
           return;
         }
       } catch(ex) {}


### PR DESCRIPTION
It looks like Slack renamed the event from `typing` to `user_typing`.

![image](https://user-images.githubusercontent.com/22801583/233051555-77becdb6-ff51-4a67-a88b-29c9ca041d2d.png)
> Observe the outgoing transmission with the type `user_typing`. This occured when I started typing.

I have not tested your extension myself, however did reference your code when writing my own userscript, and then tested the userscript in Chromium 112.0.5615.49 by pasting it into the Console and injecting it via the [Requestly](https://requestly.io/) extension.

I also had a Chrome user test it via an inject script rule in Requestly, which worked fine.

<details>
<summary>This is the userscript I used to test, click to expand!</summary>

```js
// Site-specific configuration.

/** 
 * Key/value pairs for filtering outgoing transmissions. If any match, the
 * outgoing transmission is dropped.
 * 
 * In each nested array, index 0 represents the property key, and index 1
 * represents the value it must equal to be considered a match.
 * 
 * @type {string[][]}
 */
const FILTER_CONDITIONS = [
  ["type", "user_typing"]
];

// Generic script for blocking outgoing WebSocket messages.

/**
 * The original {@link WebSocket#send} implementation.
 * 
 * @type {function}
 */
const SEND = window.WebSocket.prototype.send;

/**
 * Wrapper around the built-in {@link WebSocket#send} function, but filtering
 * events against {@link FILTER_CONDITIONS}.
 * 
 * @param {string | ArrayBufferLike | Blob | ArrayBufferView} data
 */
function preprocessedSend(data) {
  if (typeof data !== 'string') {
    console.log('Received non-string data, forwarding without check.');
    return SEND.apply(this, [data]);
  }

  try {
    const parsed = JSON.parse(data);

    for (const pair of FILTER_CONDITIONS) {
      if (parsed[pair[0]] === pair[1]) {
        return;
      }
    }

    return SEND.apply(this, [data]);
  } catch (err) {
    if (err instanceof SyntaxError) {
      console.log('Received non-JSON data, forwarding without check.');
      return SEND.apply(this, [data]);
    }

    throw err;
  }
}

window.WebSocket.prototype.send = preprocessedSend;

```